### PR TITLE
Addeded local development folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .project
+.idea
+.bundle
+vendor


### PR DESCRIPTION
Fixes JetBrains RubyMine IDE files messing with the git repository by adding the relevant folders to .gitignore
Nobody ever wants to check IDE files in, so it should be safe to do.